### PR TITLE
Update jscoverage.js

### DIFF
--- a/tasks/jscoverage.js
+++ b/tasks/jscoverage.js
@@ -6,12 +6,6 @@ module.exports = function(grunt) {
   var done = this.async();
   var options = this.options();
 
-  if (options.outputDirectory == "lib") { 
-    grunt.log.error("Are you sure you want to delete lib?  please use a different output directory");
-    done(false);
-    return;
-  }
-
   if (grunt.file.exists(options.outputDirectory)) grunt.file.delete(options.outputDirectory);
 
   var args2 = [];


### PR DESCRIPTION
I like to move my lib folder to libArchive, use lib as the output directory for coverage and then when done delete lib and move libArchive back to lib. This enables me to not have to change my code with a lot of ugly process.env garbage and I don't have to .gitignore lib-cov or any of that stuff to keep it so that I don't get yelled at by jshint.
